### PR TITLE
feat/clear-history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+tmp

--- a/chatty.py
+++ b/chatty.py
@@ -136,6 +136,13 @@ def run_conversation_loop(model_name: str, conversation_history: list, all_tools
             proxy_code = generate_tools_file_content(all_tools_metadata, GATEWAY_HOST, GATEWAY_PORT)
             ui.display_proxy_code(proxy_code)
             continue
+        elif user_input.lower() == "/clear":
+            # Re-initialize history, preserving the system prompt.
+            system_prompt = conversation_history[0]
+            conversation_history.clear()
+            conversation_history.append(system_prompt)
+            ui.display_info("Conversation history has been cleared.")
+            continue
 
         conversation_history.append({"role": "user", "content": user_input})
 

--- a/chatty.py
+++ b/chatty.py
@@ -126,6 +126,9 @@ def run_conversation_loop(model_name: str, conversation_history: list, all_tools
 
         if user_input.lower() in ["exit", "quit"]:
             break
+        elif user_input.lower() == "/help":
+            ui.display_help()
+            continue
         elif user_input.lower() == "/history":
             ui.display_history(conversation_history)
             continue

--- a/chatty.py
+++ b/chatty.py
@@ -129,6 +129,9 @@ def run_conversation_loop(model_name: str, conversation_history: list, all_tools
         elif user_input.lower() == "/history":
             ui.display_history(conversation_history)
             continue
+        elif user_input.lower() == "/history-raw":
+            ui.display_raw_history(conversation_history)
+            continue
         elif user_input.lower() == "/tools":
             ui.display_tools(all_tools_metadata)
             continue

--- a/internal/ui.py
+++ b/internal/ui.py
@@ -42,7 +42,7 @@ class TerminalUI:
             border_style="dim blue"
         )
         self.console.print(panel)
-        self.console.print("Use /history, /tools, or /proxy for info. Type 'exit' or 'quit' to end.", justify="center")
+        self.console.print("Use /clear for new chat and /history, /history-raw, /tools, or /proxy for info. Type 'exit' or 'quit' to end.", justify="center")
         self.console.print()
 
     def display_info(self, message: str):
@@ -137,6 +137,13 @@ class TerminalUI:
             style = self.theme["user"] if message["role"] == "user" else self.theme["assistant"]
             title = "👤 USER" if message["role"] == "user" else "🤖 ASSISTANT"
             self.console.print(Panel(message["content"], title=title, border_style=style, expand=False))
+        self.console.rule(style=self.theme["separator"])
+
+    def display_raw_history(self, history: List[Dict[str, str]]):
+        """Displays the raw conversation history, including system prompt, as JSON."""
+        self.console.rule("[bold]Raw Conversation History (for LLM)", style=self.theme["separator"])
+        history_json = json.dumps(history, indent=2)
+        self.console.print(Syntax(history_json, "json", theme="monokai", word_wrap=True))
         self.console.rule(style=self.theme["separator"])
 
     def display_tools(self, all_tools_metadata: List[Dict[str, Any]]):

--- a/internal/ui.py
+++ b/internal/ui.py
@@ -42,8 +42,35 @@ class TerminalUI:
             border_style="dim blue"
         )
         self.console.print(panel)
-        self.console.print("Use /clear for new chat and /history, /history-raw, /tools, or /proxy for info. Type 'exit' or 'quit' to end.", justify="center")
+        self.console.print("Type '/help' for a list of commands. Type 'exit' or 'quit' to end.", justify="center")
         self.console.print()
+
+    def display_help(self):
+        """Displays the help message with available commands."""
+        table = Table(show_header=False, box=None, expand=False)
+        table.add_column("Command", style="cyan", no_wrap=True)
+        table.add_column("Description")
+
+        commands = {
+            "/help": "Show this help message.",
+            "/clear": "Clear the current conversation history.",
+            "/history": "Show the formatted conversation history.",
+            "/history-raw": "Show the raw JSON conversation history for the LLM.",
+            "/tools": "Show available tools as a JSON object.",
+            "/proxy": "Show the generated 'tools.py' proxy code.",
+            "exit / quit": "Exit the application."
+        }
+
+        for cmd, desc in commands.items():
+            table.add_row(f"[bold]{cmd}[/bold]", desc)
+
+        panel = Panel(
+            table,
+            title="[bold]Available Commands[/]",
+            border_style="dim blue",
+            expand=False
+        )
+        self.console.print(panel)
 
     def display_info(self, message: str):
         self.console.print(f"[*] {message}", style="dim")


### PR DESCRIPTION
- Added `/clear history` command to clear chat history.
- Introduced `/history-raw` command to display the full conversation history in raw JSON format for debugging.
- Added `/help` command and simplified the startup message for better user guidance.