### PR TITLE
feat(tools): Implement return type annotations for tools

### DIFF
--- a/chatty.py
+++ b/chatty.py
@@ -270,16 +270,16 @@ def main():
         ui.console.print("\nUsage: [bold]uv run chatty.py --model <model_name>[/bold]")
         sys.exit(1)
 
-    mcp_server_configs = {}
+    mcp_config = {}
     try:
         with open(args.mcp, 'r') as f:
-            mcp_server_configs = json.load(f).get("mcpServers", {})
+            mcp_config = json.load(f)
     except FileNotFoundError:
         ui.display_warning(f"MCP config '{args.mcp}' not found. No external MCP servers will be started.")
     except json.JSONDecodeError as e:
         ui.display_error(f"Could not parse '{args.mcp}': {e}. Continuing without external MCP servers.")
 
-    mcp_manager = MCPManager(mcp_server_configs)
+    mcp_manager = MCPManager(mcp_config)
     http_server = None
     try:
         with ui.console.status("[bold green]Starting MCP servers...", spinner="dots"):

--- a/internal/internal_tools.py
+++ b/internal/internal_tools.py
@@ -34,6 +34,9 @@ INTERNAL_TOOLS_METADATA = [
                 "city": {"type": "string", "description": "The city to get the weather for."}
             },
             "required": ["city"]
+        },
+        "outputSchema": {
+            "type": "string"
         }
     },
     {
@@ -46,6 +49,9 @@ INTERNAL_TOOLS_METADATA = [
                 "b": {"type": "number", "description": "The second number."}
             },
             "required": ["a", "b"]
+        },
+        "outputSchema": {
+            "type": "integer"
         }
     }
 ]

--- a/internal/tool_scaffolding.py
+++ b/internal/tool_scaffolding.py
@@ -90,7 +90,7 @@ def generate_tools_interface_for_prompt(tools_metadata: list) -> str:
     lines = []
     for tool in tools_metadata:
         py_tool_name = tool['name'].replace('/', '_').replace('-', '_')
-        
+
         # Handle multi-line descriptions
         description = tool.get("description", "No description provided.")
         description_lines = description.strip().split('\n')
@@ -106,8 +106,16 @@ def generate_tools_interface_for_prompt(tools_metadata: list) -> str:
             param_parts.append(f"{param_name}: {param_type}")
         method_sig = ", ".join(param_parts)
 
+        # Build method definition with optional return type
+        def_line = f"def {py_tool_name}({method_sig})"
+        output_schema = tool.get('outputSchema')
+        if output_schema and 'type' in output_schema:
+            return_type = _map_json_type_to_python_type(output_schema['type'])
+            def_line += f" -> {return_type}"
+        def_line += ": ..."
+
         lines.append(f'    @staticmethod')
-        lines.append(f'    def {py_tool_name}({method_sig}): ...')
+        lines.append(f'    {def_line}')
         lines.append('')
-    
+
     return "class Tools:\n" + "\n".join(lines).strip()

--- a/mcp-config/demo-and-fetch.json
+++ b/mcp-config/demo-and-fetch.json
@@ -1,10 +1,17 @@
 {
   "mcpServers": {
-    "server-fetch": { 
+    "server-fetch": {
       "run": "uvx mcp-server-fetch"
     },
     "demo-mcp-server": {
       "run": "uv run demo-mcp-server/server.py"
+    }
+  },
+  "tool_patches": {
+    "fetch": {
+      "outputSchema": {
+        "type": "string"
+      }
     }
   }
 }


### PR DESCRIPTION
Introduces support for specifying tool return types to provide clearer interfaces for the LLM. This is implemented via a new outputSchema in tool metadata.

  MCP Tools: A new tool_patches section is added to mcp-config/*.json to allow augmenting metadata from external MCP servers. This is used to add an outputSchema for the fetch tool. MCPManager now reads and applies these patches.

  Internal Tools: The metadata for internal tools (get_weather, multiply_numbers) is updated with an outputSchema to match their function signatures.

  Prompt Generation: The generate_tools_interface_for_prompt function now reads the outputSchema and includes a Python return type hint in the Tools class interface presented to the LLM.

  Configuration: The main chatty.py script now passes the entire MCP configuration object to MCPManager to support tool_patches.