### PR TITLE
feat/dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# 1. Base image with Python & system tools
+FROM python:3.11-slim
+
+# 2. Install node, npm, git, curl
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      curl \
+      git \
+      gnupg2 && \
+    # Node.js 18.x
+    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y nodejs && \
+    # Install Astral uv, and make it available globally
+    curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    cp /root/.local/bin/uv /usr/local/bin/uv && \
+    cp /root/.local/bin/uvx /usr/local/bin/uvx && \
+    # cleanup
+    apt-get purge -y --auto-remove curl gnupg2 && \
+    rm -rf /var/lib/apt/lists/*
+
+# 3. Create & switch to non-root user
+ARG UNAME=developer
+ARG UID=1000
+RUN useradd --create-home --shell /bin/bash --uid $UID $UNAME
+
+USER $UNAME
+WORKDIR /home/$UNAME/chatty
+
+# 4. Copy the entire project
+COPY --chown=$UNAME:$UNAME . .
+
+# 5. Expose app port
+EXPOSE 8000
+
+# 6. Run chatty
+ENTRYPOINT ["uv", "run", "chatty.py"]
+CMD ["--ollama", "http://host.docker.internal:11434", \
+     "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_NAME="chatty"
+
+echo "🛠  Building Docker image ${IMAGE_NAME}..."
+docker build -t "${IMAGE_NAME}" .
+echo "✅  Built ${IMAGE_NAME}"

--- a/scripts/copy-out.sh
+++ b/scripts/copy-out.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+USAGE="Usage: $0 <container-path> [<host-dest>]"
+if [[ $# -lt 1 ]]; then
+  echo "$USAGE"
+  exit 1
+fi
+
+CONTAINER_PATH="$1"
+HOST_DEST="${2:-.}"
+
+IMAGE_NAME="chatty"
+CONTAINER_ID=$(docker ps -q --filter "ancestor=${IMAGE_NAME}")
+
+if [[ -z "$CONTAINER_ID" ]]; then
+  echo "⚠️  No running container for image ${IMAGE_NAME}"
+  exit 1
+fi
+
+echo "📦  Copying ${CONTAINER_ID}:${CONTAINER_PATH} → ${HOST_DEST}"
+docker cp "${CONTAINER_ID}:${CONTAINER_PATH}" "${HOST_DEST}"
+echo "✅  Done."

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_NAME="chatty"
+HOST_PORT=8000
+CONTAINER_PORT=8000
+WORKDIR="$(pwd)"
+CONTAINER_WORKDIR="/home/developer/chatty"
+
+if [[ $# -lt 1 ]]; then
+  echo "❌  Usage: $0 <model-name>"
+  exit 1
+fi
+MODEL="$1"
+shift
+
+OLLAMA_URL="http://host.docker.internal:11434"
+
+echo "🚀  Starting dev container with model=${MODEL}…"
+docker run -d --rm \
+  -p ${HOST_PORT}:${CONTAINER_PORT} \
+  -v "${WORKDIR}:${CONTAINER_WORKDIR}:rw" \
+  --name chatty-dev \
+  "${IMAGE_NAME}" \
+    --model "${MODEL}" \
+    --ollama "${OLLAMA_URL}" \
+    --host "0.0.0.0" --port "8000" --reload
+
+echo "✅  Dev container started. Access it at http://localhost:${HOST_PORT}"
+echo "🔍  To attach a shell: scripts/exec.sh"

--- a/scripts/exec.sh
+++ b/scripts/exec.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONTAINER_NAME="chatty-dev"
+
+# Check if it's running
+if ! docker ps --filter "name=^/${CONTAINER_NAME}$" --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+  echo "⚠️  No running container named ${CONTAINER_NAME}"
+  exit 1
+fi
+
+echo "🔍  Exec’ing into container ${CONTAINER_NAME}"
+docker exec -it "${CONTAINER_NAME}" /bin/bash

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_NAME="chatty"
+HOST_PORT=8000
+CONTAINER_PORT=8000
+
+echo "▶️  Running ${IMAGE_NAME}.."
+
+docker run --rm \
+  -p 8000:8000 \
+  -it \
+  -v "$(pwd)":/home/developer/chatty:rw \
+  chatty \
+    --model qwen2.5-coder:7b \
+    --ollama http://host.docker.internal:11434


### PR DESCRIPTION
- Added `--ollama` CLI argument to configure the Ollama API URL, defaulting to `http://localhost:11434`.
- Introduced `AppContext` dataclass to centralize application state and configuration.
- Refactored core conversation loop functions to use the new context object.
- Updated bootstrap functions to accept Ollama URL directly.
- Added Docker support with a Dockerfile and helper scripts for containerized development and production:
  - Dockerfile uses Python 3.11-slim with Node.js, Git, and Astral uv.
  - Runs as non-root “developer” user, connecting to Ollama API via host.docker.internal.
  - Scripts include build.sh, dev.sh, run.sh, exec.sh, and copy-out.sh for building, running, and managing containers.