### PR TITLE
feat(mcp): Implement hot-reloading and standard config format

### DIFF
--- a/internal/ui.py
+++ b/internal/ui.py
@@ -54,7 +54,7 @@ class TerminalUI:
         commands = {
             "/help": "Show this help message.",
             "/clear": "Clear the current conversation history.",
-            "/reload": "Reload prompts from the 'prompts/' directory.",
+            r"/reload \[prompts|mcp]": "Reload prompts, MCP servers, or both from disk.",
             "/history": "Show the formatted conversation history.",
             "/history-raw": "Show the raw JSON conversation history for the LLM.",
             "/tools": "Show available tools as a JSON object.",

--- a/mcp-config/demo-and-fetch.json
+++ b/mcp-config/demo-and-fetch.json
@@ -1,7 +1,10 @@
 {
   "mcpServers": {
     "server-fetch": {
-      "run": "uvx mcp-server-fetch"
+      "command": "uvx",
+      "args": [
+        "mcp-server-fetch"
+      ]
     },
     "demo-mcp-server": {
       "run": "uv run demo-mcp-server/server.py"


### PR DESCRIPTION
This commit introduces two major enhancements to the MCP integration:

1.  **MCP Hot-Reloading:**    The `MCPManager` now supports being reloaded at runtime. A new `/reload mcp` command allows users to shut down existing MCP servers and start new ones based on an updated configuration file, making the system truly hot-pluggable without restarting the agent. The `/reload` command can now target `prompts`, `mcp`, or both.
2.  **Standard MCP Configuration Format:**    In addition to the legacy `run` key, the agent now supports the more common `command`/`args`/`env` structure for defining MCP servers in the JSON configuration. This improves compatibility with other tools in the MCP ecosystem. Both formats can be used concurrently.
The implementation follows a robust, encapsulated design by adding a `reload()` method to `MCPManager`, ensuring it remains responsible for its own lifecycle.
