### PR TITLE
fix(agents): correct agent tool contract to prevent runtime errors

### DIFF
--- a/internal/agent_tools.py
+++ b/internal/agent_tools.py
@@ -52,7 +52,7 @@ class AgentTools:
             },
             {
                 "name": "wait_for_agents",
-                "description": "Waits for one or more agents/tasks to complete. This is a blocking call for the current script. Returns a dictionary of {agent_id: result}.",
+                "description": "Waits for one or more agents/tasks to complete. CRITICAL: This function signals the host application to run the agents. Your script should simply print the output of this function and exit. The actual results of the agents will be provided in your next turn in the TOOL_EXECUTION_RESULT.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
@@ -64,7 +64,10 @@ class AgentTools:
                     },
                     "required": ["agent_ids"]
                 },
-                "outputSchema": {"type": "object", "description": "A dictionary mapping each agent_id to its final result."}
+                "outputSchema": {
+                    "type": "string",
+                    "description": "A special directive string that your script MUST print. Do not attempt to parse or use this string."
+                }
             }
         ]
 

--- a/prompts/system.txt
+++ b/prompts/system.txt
@@ -82,31 +82,59 @@ Only use {TOOL_CODE_TAG_START} and {TOOL_CODE_TAG_END} tags single time in your 
 **AGENT ORCHESTRATION**
 You can decompose complex tasks by spawning sub-agents. This is a powerful feature for planning, coding, and reviewing in separate, focused contexts.
 
-**Workflow:**
-1.  Use `spawn_agent` to create one or more sub-agents. This call is non-blocking and returns an `agent_id` immediately.
-2.  Use `wait_for_agents` with the list of `agent_id`s. This call WILL block until all specified agents are finished.
-3.  The return value will be a dictionary containing the results from each agent, which you can then process.
+**CRITICAL: This is a two-turn process.**
+1.  **Turn 1 (Your script):** You spawn agents and then call `wait_for_agents`. Your script's only job is to `print` the string returned by `wait_for_agents` and then exit. Do not try to process the result in the same script.
+2.  **Turn 2 (System Response):** The system will run the agents and provide their results back to you in the `TOOL_EXECUTION_RESULT` of your next turn.
+3.  **Turn 3 (Your next script):** You will then be prompted again. Now, you can analyze the results from the previous turn and continue your task, potentially by writing a new script.
 
-**Example:**
+**Example Workflow:**
+
+**Your First Script (Spawning and Waiting):**
 ```python
+{TOOL_CODE_TAG_START}
 # dependencies = []
 import sys
 from tools import Tools, MCPToolError
 
 try:
-    # 1. Spawn a "planner" agent
-    planner_id = Tools.spawn_agent(role="Planner", prompt="Create a step-by-step plan to fetch and summarize the content of example.com.")
+    # 1. Spawn a "planner" agent to create a plan.
+    planner_id = Tools.spawn_agent(
+        role="Planner",
+        prompt="Create a step-by-step plan to fetch and summarize the content of example.com."
+    )
     
-    # 2. Wait for the planner to finish
-    results = Tools.wait_for_agents(agent_ids=[planner_id])
-    
-    plan = results[planner_id]['result']
-    print(f"The plan is: {plan}")
-    
-    # You can now parse this plan and spawn more agents to execute the steps.
+    # 2. End the script by printing the wait directive. DO NOT try to use the return value here.
+    print(Tools.wait_for_agents(agent_ids=[planner_id]))
     
 except MCPToolError as e:
     print(f"A tool error occurred: {e}", file=sys.stderr)
 except Exception as e:
     print(f"An unexpected script error occurred: {e}", file=sys.stderr)
+{TOOL_CODE_TAG_END}
+```
+
+**(The system will then show you a `TOOL_EXECUTION_RESULT` that looks like this:)**
+```json
+{
+  "agent-planner-1": {
+    "status": "completed",
+    "result": "1. Fetch the content from https://example.com using the 'fetch' tool. 2. Identify the main text. 3. Summarize the text into 3 sentences."
+  }
+}
+```
+
+**Your Second Script (Processing the Results):**
+After seeing the above result, you would continue the conversation. For example:
+"Okay, I have the plan. Now I will execute step 1."
+```python
+{TOOL_CODE_TAG_START}
+# dependencies = []
+import sys
+from tools import Tools, MCPToolError
+try:
+    content = Tools.fetch(url="https://example.com")
+    print(content)
+except MCPToolError as e:
+    print(f"Tool failed: {e}", file=sys.stderr)
+{TOOL_CODE_TAG_END}
 ```


### PR DESCRIPTION
The `wait_for_agents` tool was incorrectly documented, promising a dictionary result within the same turn. This caused the LLM to generate code that immediately tried to process a return value, resulting in a `TypeError` because the tool actually returns a string directive for the main loop.



This commit fixes the issue by:

1.  Updating the `outputSchema` and `description` for `wait_for_agents` in `internal/agent_tools.py` to accurately reflect that it returns a directive string and that results are only available in the next turn.

2.  Rewriting the `AGENT ORCHESTRATION` guide in `prompts/system.txt` with a clear, two-turn example that demonstrates the correct spawn-wait-process workflow.



This ensures the LLM has an accurate understanding of the tool's behavior, preventing it from generating faulty code.