### PR TITLE
feat: Restore meta-commands and streaming responses

### DIFF
--- a/internal/context.py
+++ b/internal/context.py
@@ -20,8 +20,11 @@ class AppContext:
     ui: 'TerminalUI'
     prompt_manager: 'PromptManager'
     all_tools_metadata: List[Dict[str, Any]]
+    agent_tools_metadata: List[Dict[str, Any]]
+    execute_code_metadata: Dict[str, Any]
     mcp_manager: 'MCPManager'
     agent_manager: 'AgentManager'
     kernel: Optional['Kernel']
     temperature: float
+    streaming: bool
     auto_accept_code: bool = False

--- a/internal/kernel.py
+++ b/internal/kernel.py
@@ -2,7 +2,9 @@
 import json
 import logging
 import re
-from typing import List, Dict, Any, Callable, TYPE_CHECKING
+import requests
+import sys
+from typing import List, Dict, Any, Callable, TYPE_CHECKING, Tuple
 
 from .agent_manager import AgentContext, AgentManager, AgentStatus
 from .agent_prompt import TOOL_TAG_START, TOOL_TAG_END
@@ -10,7 +12,6 @@ from .ui import TerminalUI
 
 if TYPE_CHECKING:
     from .mcp_manager import MCPManager
-
 
 class Kernel:
     """Orchestrates the agent lifecycle, including LLM interaction, tool use, and state management."""
@@ -21,40 +22,47 @@ class Kernel:
         agent_manager: AgentManager,
         mcp_manager: 'MCPManager',
         all_tool_impls: Dict[str, Callable],
-        llm_caller: Callable,
         system_prompt_generator: Callable,
         auto_accept_code: bool,
+        ollama_base_url: str,
+        model_name: str,
+        temperature: float,
+        streaming: bool,
     ):
         self.ui = ui
         self.agent_manager = agent_manager
         self.mcp_manager = mcp_manager
         self.all_tool_impls = all_tool_impls
-        self.llm_caller = llm_caller
         self.system_prompt_generator = system_prompt_generator
         self.auto_accept_code = auto_accept_code
+        self.ollama_base_url = ollama_base_url
+        self.model_name = model_name
+        self.temperature = temperature
+        self.streaming = streaming
         self._tool_call_id_counter = 0
 
     def run_turn(self, agent: AgentContext):
         """Executes one full 'turn' for a given agent."""
         agent.status = AgentStatus.RUNNING
         self.ui.display_agent_activity(agent.id, agent.role, "starting turn...")
-        
-        # Ensure the agent has the latest system prompt, especially sub-agents
+
         if agent.history and agent.history[0]["role"] == "system":
-             agent.history[0]["content"] = self.system_prompt_generator()
+            agent.history[0]["content"] = self.system_prompt_generator()
         
-        response_text = self.llm_caller(agent.history)
-        
+        response_text, interrupted = self._call_llm(agent)
+        if interrupted:
+            agent.status = AgentStatus.DONE
+            return
+
         tool_content = self._extract_tool_content(response_text)
 
         if not tool_content:
-            # This is a final, text-only response.
-            self.ui.display_final_answer(agent.id, agent.role, response_text)
+            if not (self.streaming and agent.is_main):
+                self.ui.display_final_answer(agent.id, agent.role, response_text)
             agent.history.append({"role": "assistant", "content": response_text})
             agent.status = AgentStatus.DONE
             return
 
-        # It's a tool call. Append the assistant's thought process and the tool call to history.
         full_assistant_message = f"{TOOL_TAG_START}\n{tool_content}\n{TOOL_TAG_END}"
         agent.history.append({"role": "assistant", "content": full_assistant_message})
 
@@ -66,7 +74,7 @@ class Kernel:
             error_message = f"Error: Invalid tool format. Expected a JSON list within <tool> tags. Parser error: {e}"
             self.ui.display_error(error_message)
             agent.history.append({"role": "user", "content": f"TOOL_EXECUTION_RESULT:\n{error_message}"})
-            agent.status = AgentStatus.READY # Let the agent try to recover.
+            agent.status = AgentStatus.READY
             return
         
         tool_results = self._execute_tool_calls(agent, tool_calls)
@@ -74,10 +82,58 @@ class Kernel:
         feedback_msg = f"TOOL_EXECUTION_RESULT:\n```json\n{json.dumps(tool_results, indent=2)}\n```"
         agent.history.append({"role": "user", "content": feedback_msg})
 
-        # If an agent calls wait, its status is set to WAITING inside _execute_tool_calls.
-        # Otherwise, it's ready for the next thinking step.
         if agent.status != AgentStatus.WAITING:
             agent.status = AgentStatus.READY
+
+    def _call_llm(self, agent: AgentContext) -> Tuple[str, bool]:
+        """Calls the LLM, either streaming or non-streaming based on configuration."""
+        if self.streaming and agent.is_main:
+            return self._call_llm_stream(agent.history)
+        return self._call_llm_non_stream(agent.history)
+
+    def _call_llm_stream(self, messages_history: list) -> Tuple[str, bool]:
+        url = f"{self.ollama_base_url}/api/chat"
+        payload = {"model": self.model_name, "messages": messages_history, "stream": True, "options": {"temperature": self.temperature}}
+        full_response_content = ""
+        
+        if not any(msg['role'] == 'assistant' and self._extract_tool_content(msg['content']) for msg in messages_history):
+            self.ui.display_assistant_response_start()
+            
+        try:
+            with requests.post(url, json=payload, stream=True, timeout=300) as response:
+                response.raise_for_status()
+                for line in response.iter_lines():
+                    if line:
+                        chunk = json.loads(line.decode('utf-8'))
+                        content = chunk.get('message', {}).get('content', '')
+                        if content:
+                            self.ui.display_assistant_stream_chunk(content)
+                            full_response_content += content
+                        if chunk.get("done"):
+                            break
+        except requests.RequestException as e:
+            logging.critical(f"Ollama connection error: {e}. Exiting.")
+            sys.exit(1)
+        except KeyboardInterrupt:
+            self.ui.display_warning("\nLLM generation interrupted by user.")
+            return full_response_content, True
+        finally:
+             self.ui.display_assistant_response_end()
+
+        return full_response_content, False
+
+    def _call_llm_non_stream(self, messages_history: list) -> Tuple[str, bool]:
+        url = f"{self.ollama_base_url}/api/chat"
+        payload = {"model": self.model_name, "messages": messages_history, "stream": False, "options": {"temperature": self.temperature}}
+        try:
+            response = requests.post(url, json=payload, timeout=300)
+            response.raise_for_status()
+            full_response = response.json()
+            content = full_response.get('message', {}).get('content', '')
+            return content, False
+        except requests.RequestException as e:
+            logging.error(f"LLM call failed: {e}")
+            return f"Error: Could not contact LLM. {e}", False
 
     def _execute_tool_calls(self, agent: AgentContext, tool_calls: List[Dict]) -> List[Dict]:
         """Executes a list of tool calls, handling dependencies and special directives."""
@@ -89,7 +145,6 @@ class Kernel:
             tool_args = call.get("arguments", {})
             tool_call_id = call.get("call_id", self._get_next_tool_call_id())
 
-            # Resolve references in arguments
             try:
                 resolved_args = self._resolve_argument_references(tool_args, call_results_by_id)
             except ValueError as e:
@@ -98,18 +153,14 @@ class Kernel:
                 call_results_by_id[tool_call_id] = result
                 continue
 
-            # --- Special Agent-Orchestration Tools ---
             if tool_name == "wait_for_agents":
                 agent.status = AgentStatus.WAITING
                 self.ui.display_info("Wait directive received. Agent is now waiting.")
-                # The result for this tool call will be populated later by the main loop
-                # once the sub-agents are finished. For now, we just mark it.
                 result = {"status": "success", "output": "Agent is now waiting for sub-agents to complete."}
                 results.append({"call_id": tool_call_id, "result": result})
                 call_results_by_id[tool_call_id] = result
-                continue # Stop processing further tools in this turn
+                continue
 
-            # --- Confirmation & Dispatch for Regular Tools ---
             action_type = "CODE_EXECUTION" if tool_name == "execute_python_code" else "TOOL_CALL"
             details = resolved_args.get('code', "") if tool_name == 'execute_python_code' else json.dumps(call, indent=2)
 
@@ -118,28 +169,26 @@ class Kernel:
                     if not tool_name or not isinstance(tool_name, str):
                         raise ValueError("Tool name is missing or invalid in the tool call.")
                     
+                    if tool_name == "spawn_agent":
+                        agent_tools_instance = self.all_tool_impls[tool_name].__self__
+                        agent_tools_instance.system_prompt = self.system_prompt_generator()
+
                     logging.info(f"Agent '{agent.id}' executing tool '{tool_name}' with args: {resolved_args}")
                     
                     if tool_name in self.all_tool_impls:
-                        # Internal tools, including `execute_python_code` and `spawn_agent`
                         output = self.all_tool_impls[tool_name](**resolved_args)
                         result = {"status": "success", "output": output}
                     elif tool_name in self.mcp_manager._tool_to_server_map:
-                        # MCP tools
                         mcp_result = self.mcp_manager.dispatch_tool_call(tool_name, resolved_args)
                         if mcp_result is None:
                             raise ConnectionError(f"MCP tool dispatch for '{tool_name}' failed. The server may be down or the tool unavailable.")
                         
-                        # Normalize MCP result
                         if mcp_result.get("isError"):
                             error_content = mcp_result.get("content", [{}])[0].get("text", "Unknown MCP tool error")
                             raise Exception(error_content)
                         
                         content = mcp_result.get("content", [])
-                        if len(content) == 1 and content[0].get("type") == "text":
-                            output = content[0]["text"]
-                        else:
-                            output = content
+                        output = content[0]["text"] if len(content) == 1 and content[0].get("type") == "text" else content
                         result = {"status": "success", "output": output}
                     else:
                         raise KeyError(f"Tool '{tool_name}' not found.")


### PR DESCRIPTION
This commit re-implements two major features from a previous version into the new agent-based architecture: meta-commands and streaming LLM responses.

- **Meta-Commands:**

  - The `/help`, `/history`, `/reload`, `/clear`, `/tools`, and `/proxy` commands are now functional.

  - The main application loop in `chatty.py` handles command parsing.

  - `internal/ui.py` has been updated with corresponding display methods to provide rich, formatted output for each command.



- **Streaming LLM Responses:**

  - LLM responses now stream by default for a better user experience.

  - A `--no-streaming` flag has been added to disable this behavior.

  - The `Kernel` now manages all LLM communication, supporting both streaming and non-streaming modes. It intelligently streams only for the main agent's responses.

  - Graceful `KeyboardInterrupt` handling is included for streaming.



- **Bug Fix:**

  - Fixed a bug where sub-agents spawned via the `spawn_agent` tool were not receiving the system prompt. The `Kernel` now correctly injects the prompt before tool execution.